### PR TITLE
use npm's publishConfig to allow installation via git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tsc": "rimraf lib && tsc",
     "test": "npm run lint && preview && ts-node test --type-check && mos t",
     "md": "mos",
-    "prepublishOnly": "npm run tsc"
+    "prepare": "npm run tsc"
   },
   "repository": {
     "type": "git",
@@ -80,5 +80,8 @@
     "installation": {
       "useShortAlias": true
     }
+  },
+  "publishConfig": {
+    "scripts": {}
   }
 }


### PR DESCRIPTION
While a registry may have its perks, being able to install a package straight from its git source has great value in itself.

But maybe you have considered similar changes before and reasoned against them?

Side-effect: `git clone ... && npm i` just works. No need to know which script to run in order to build.